### PR TITLE
Increase Easynews timeout

### DIFF
--- a/src/main/kotlin/io/skjaere/debridav/debrid/client/easynews/EasynewsClient.kt
+++ b/src/main/kotlin/io/skjaere/debridav/debrid/client/easynews/EasynewsClient.kt
@@ -35,7 +35,7 @@ import java.nio.charset.StandardCharsets
 import java.time.Instant
 import java.util.*
 
-const val TIMEOUT_MS = 5_000L
+const val TIMEOUT_MS = 15_000L
 const val RETRIES = 3L
 const val MINIMUM_RUNTIME_SECONDS = 360L
 const val MINIMUM_RELEASE_SIZE_MB = 400


### PR DESCRIPTION
## Summary
- extend Easynews HTTP client timeout to 15s

## Testing
- `./gradlew test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684b6ab1e358832ea46769346a0faa4f